### PR TITLE
POE / 2.5GE option added - updated config and workflow yaml, also removed some account name hardcoding.

### DIFF
--- a/.github/workflows/bpi-r4-BE14-janusz.yaml
+++ b/.github/workflows/bpi-r4-BE14-janusz.yaml
@@ -5,12 +5,17 @@ name: BPI-R4 + BE14 + EHT fix by Janusz + luci BE
 
 on:
   workflow_dispatch:
+    inputs:
+      DEVICE_CONFIG:
+        description: "Device configuration selection (default: non-poe)"
+        required: false
+        default: ""
 
 env:
   REMOTE_REPOSITORY: danpawlik/openwrt
   REMOTE_BRANCH: be14-janusz-v12-luci
   RELEASE_PREFIX: Mediatek_mt7988a_bpi-r4_be14_eht
-  DEVICE_CONFIG: configs/mediatek/mt7988a/bpi-r4
+  DEVICE_CONFIG: ${{ inputs.DEVICE_CONFIG == 'poe' && 'configs/mediatek/mt7988a/bpi-r4-poe' || 'configs/mediatek/mt7988a/bpi-r4' }}
   ROLE_CONFIG: configs/common/main-router
 
 jobs:
@@ -59,13 +64,13 @@ jobs:
 
       - name: Configure firmware image
         run: |
-          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/mediatek/mt7988a/bpi-r4 > .config
-          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/common/luci >> .config
-          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/common/snapshot-short >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/${{ env.DEVICE_CONFIG }} > .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/luci >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/snapshot-short >> .config
           sed -i '/CONFIG_PACKAGE_wpad-mbedtls=y/d' .config
-          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/common/openssl >> .config
-          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/common/lte-5g-modem >> .config
-          curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/common/community >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/openssl >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/lte-5g-modem >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/community >> .config
 
       - name: Run defconfig
         run: |

--- a/configs/mediatek/mt7988a/bpi-r4-poe
+++ b/configs/mediatek/mt7988a/bpi-r4-poe
@@ -1,7 +1,9 @@
 #
-# curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/mediatek/mt7988a/bpi-r4 > .config
+# curl -SL https://raw.githubusercontent.com/danpawlik/openwrt-builder/master/configs/mediatek/mt7988a/bpi-r4-poe > .config
 #
 
 CONFIG_TARGET_mediatek=y
 CONFIG_TARGET_mediatek_filogic=y
-CONFIG_TARGET_mediatek_filogic_DEVICE_bananapi_bpi-r4=y
+CONFIG_TARGET_mediatek_filogic_DEVICE_bananapi_bpi-r4-poe=y
+
+CONFIG_PACKAGE_mt7988-2p5g-phy-firmware=y


### PR DESCRIPTION
1. Updated the bpi-r4-BE14-janusz.yaml to take an optional parameter of 'poe' to build the poe version.
2. Updated the poe config file to have the correct target and explicitly load the 2.5GE firmware.
3. Replaced the hardcoded github account name in the curls to make forking easier (might make people more willing to update their own config files.)