### PR TITLE
Update bpi-r4-BE14-community.yaml

### DIFF
--- a/.github/workflows/bpi-r4-BE14-community.yaml
+++ b/.github/workflows/bpi-r4-BE14-community.yaml
@@ -61,15 +61,21 @@ jobs:
         run: |
           ./scripts/feeds update -a && ./scripts/feeds install -a
 
+      - name: environment variable - add date
+        run: echo "RELEASE_DATE=$(date +%F)" >> $GITHUB_ENV
+
+      - name: environment variable - add release branch
+        run: echo "RELEASE_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+
       - name: Configure firmware image
         run: |
-          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/${{ env.DEVICE_CONFIG }} > .config
-          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/luci >> .config
-          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/snapshot-short >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/${{ env.RELEASE_BRANCH }}/${{ env.DEVICE_CONFIG }} > .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/${{ env.RELEASE_BRANCH }}/configs/common/luci >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/${{ env.RELEASE_BRANCH }}/configs/common/snapshot-short >> .config
           sed -i '/CONFIG_PACKAGE_wpad-mbedtls=y/d' .config
-          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/openssl >> .config
-          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/configs/common/lte-5g-modem >> .config
-          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/master/${{ env.ROLE_CONFIG }} >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/${{ env.RELEASE_BRANCH }}/configs/common/openssl >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/${{ env.RELEASE_BRANCH }}/configs/common/lte-5g-modem >> .config
+          curl -SL https://raw.githubusercontent.com/${{ github.repository_owner }}/openwrt-builder/${{ env.RELEASE_BRANCH }}/${{ env.ROLE_CONFIG }} >> .config
 
       - name: Run defconfig
         run: |
@@ -85,6 +91,9 @@ jobs:
       - name: Compress all packages
         run: |
           tar caf bin/targets/mediatek/filogic/packages.tar.gz bin/targets/mediatek/filogic/packages
+
+      - name: rename release files
+        run: for f in bin/targets/mediatek/filogic/openwrt-mediatek-filogic-bananapi_bpi-r4*; do mv "$f" "$(echo "$f" | sed s/openwrt-mediatek-filogic-bananapi_bpi-r4/openwrt-${{ env.RELEASE_DATE }}-${{ env.RELEASE_BRANCH }}-mediatek-filogic-bananapi_bpi-r4/)"; done
 
       - name: Package output
         run: tar -cvf bpi_r4-images.tar bin/targets/mediatek/filogic


### PR DESCRIPTION
Suggested change to customise the naming scheme of the generated images to keep a better overview.

If you download a whole bunch of images for testing, it is easy to lose track. Clearly naming the files can bring back some clarity ;-)

This is just a suggested change only.
No bug or big functional improvement - accept if you think this is useful for you and/or community.
... or simply discard it if it offers no meaningful added value. ;-)

In addition, the selection of the branch from which the configuration is built via curl is further dynamised.